### PR TITLE
Use formatarMoeda for currency formatting

### DIFF
--- a/src/components/FechamentoDia.tsx
+++ b/src/components/FechamentoDia.tsx
@@ -5,6 +5,7 @@ import { Espetinho } from '../types/Espetinho';
 import { Pagamento } from '../types/Pagamento';
 import _ from 'lodash';
 import { useNavigation } from '../hooks/useNavigation';
+import { formatarMoeda } from '../functions/formatar-moeda';
 
 interface FechamentoDiaProps {
   saldoInicial: number;
@@ -60,20 +61,20 @@ export function FechamentoDia({
               <div className="flex justify-between items-center">
                 <span className="text-gray-600">Saldo Inicial:</span>
                 <span className="font-semibold text-gray-900">
-                  R$ {(saldoInicial || 0).toFixed(2)}
+                  {formatarMoeda(saldoInicial || 0)}
                 </span>
               </div>
 
               <div className="flex justify-between items-center">
                 <span className="text-gray-600">Total Vendido:</span>
-                <span className="font-semibold text-orange-600">R$ {totalVendido.toFixed(2)}</span>
+                <span className="font-semibold text-orange-600">{formatarMoeda(totalVendido)}</span>
               </div>
 
               <div className="border-t border-gray-200 pt-4">
                 <div className="flex justify-between items-center">
                   <span className="text-lg font-medium text-gray-900">Saldo Final:</span>
                   <span className="text-xl font-bold text-orange-600">
-                    R$ {(saldoAtual || 0).toFixed(2)}
+                    {formatarMoeda(saldoAtual || 0)}
                   </span>
                 </div>
               </div>

--- a/src/components/GerenciarClientes.tsx
+++ b/src/components/GerenciarClientes.tsx
@@ -16,6 +16,7 @@ import { Venda } from '../types/Venda';
 import { formatarDataHora } from '../functions/formatar-data-hora';
 import { useNavigation } from '../hooks/useNavigation';
 import { TextField } from './TextField';
+import { formatarMoeda } from '../functions/formatar-moeda';
 
 interface GerenciarClientesProps {
   clientes: Cliente[];
@@ -159,7 +160,7 @@ export function GerenciarClientes({
                       </div>
                       <div className="text-right">
                         <p className="text-lg font-bold text-orange-600">
-                          R$ {totalGasto.toFixed(2)}
+                          {formatarMoeda(totalGasto)}
                         </p>
                         <p className="text-xs text-gray-500">total gasto</p>
                       </div>
@@ -270,7 +271,7 @@ export function GerenciarClientes({
                 <div className="flex items-center gap-2">
                   <DollarSign size={16} />
                   <span>
-                    Total gasto: R$ {modalDetalhesCliente.cliente.totalCompras.toFixed(2)}
+                    Total gasto: {formatarMoeda(modalDetalhesCliente.cliente.totalCompras)}
                   </span>
                 </div>
               </div>
@@ -300,7 +301,7 @@ export function GerenciarClientes({
                             </p>
                           </div>
                           <p className="font-bold text-orange-600">
-                            R$ {venda.valorTotal.toFixed(2)}
+                            {formatarMoeda(venda.valorTotal)}
                           </p>
                         </div>
                       </div>

--- a/src/components/GerenciarPagamentos.tsx
+++ b/src/components/GerenciarPagamentos.tsx
@@ -18,6 +18,7 @@ import { formatarDataHora } from '../functions/formatar-data-hora';
 import { useNavigation } from '../hooks/useNavigation';
 import { formataMetodoPagamento } from '../functions/formatar-metodo-pagamento';
 import { QrCodePix } from './QrCodePix';
+import { formatarMoeda } from '../functions/formatar-moeda';
 
 interface GerenciarPagamentosProps {
   pedidos: Pedido[];
@@ -129,7 +130,7 @@ export function GerenciarPagamentos({
               <DollarSign size={24} />
               <div>
                 <p className="text-red-100 text-sm font-medium">Total Pendente</p>
-                <p className="text-2xl font-bold">R$ {totalPendente.toFixed(2)}</p>
+                <p className="text-2xl font-bold">{formatarMoeda(totalPendente)}</p>
               </div>
             </div>
           </div>
@@ -199,7 +200,7 @@ export function GerenciarPagamentos({
                                 </div>
                                 <div className="text-right">
                                   <p className="font-semibold text-gray-900">
-                                    R$ {pedido.valorTotal.toFixed(2)}
+                                    {formatarMoeda(pedido.valorTotal)}
                                   </p>
                                 </div>
                               </div>
@@ -212,7 +213,7 @@ export function GerenciarPagamentos({
                     <div className="flex justify-between items-center pt-4 border-t border-gray-200">
                       <div>
                         <p className="text-lg font-bold text-red-600">
-                          Total: R$ {totalCliente.toFixed(2)}
+                          Total: {formatarMoeda(totalCliente)}
                         </p>
                         <p className="text-sm text-gray-600">
                           {pedidosDoCliente.length}{' '}
@@ -272,7 +273,7 @@ export function GerenciarPagamentos({
                       </div>
                       <div className="text-right">
                         <p className="text-lg font-bold text-green-600">
-                          R$ {pagamento.valorTotal.toFixed(2)}
+                          {formatarMoeda(pagamento.valorTotal)}
                         </p>
                         <p className="text-xs text-green-500">Pago</p>
                       </div>
@@ -333,7 +334,7 @@ export function GerenciarPagamentos({
                             </div>
                           </div>
                           <p className="font-semibold text-gray-900">
-                            R$ {pedido.valorTotal.toFixed(2)}
+                            {formatarMoeda(pedido.valorTotal)}
                           </p>
                         </div>
                       </div>
@@ -412,7 +413,7 @@ export function GerenciarPagamentos({
               <div className="flex justify-between items-center">
                 <span className="font-semibold text-gray-900">Total a Receber:</span>
                 <span className="text-xl font-bold text-green-600">
-                  R$ {calcularTotalSelecionado().toFixed(2)}
+                  {formatarMoeda(calcularTotalSelecionado())}
                 </span>
               </div>
               <p className="text-sm text-gray-600 mt-1">

--- a/src/components/HistoricoVendas.tsx
+++ b/src/components/HistoricoVendas.tsx
@@ -4,6 +4,7 @@ import { useScrollToTop } from '../hooks/useScrollToTop';
 import { formatarDataHora } from '../functions/formatar-data-hora';
 import { useNavigation } from '../hooks/useNavigation';
 import _ from 'lodash';
+import { formatarMoeda } from '../functions/formatar-moeda';
 
 interface HistoricoVendasProps {
   vendas: Venda[];
@@ -46,7 +47,7 @@ export function HistoricoVendas({ vendas }: HistoricoVendasProps) {
                 <DollarSign size={24} />
                 <div>
                   <p className="text-orange-100 text-sm font-medium">Total Vendido</p>
-                  <p className="text-2xl font-bold">R$ {totalVendido.toFixed(2)}</p>
+                  <p className="text-2xl font-bold">{formatarMoeda(totalVendido)}</p>
                 </div>
               </div>
             </div>
@@ -102,10 +103,10 @@ export function HistoricoVendas({ vendas }: HistoricoVendasProps) {
                           </h3>
                           <div className="text-right ml-3">
                             <p className="text-xl font-bold text-orange-600">
-                              R$ {venda.valorTotal.toFixed(2)}
+                              {formatarMoeda(venda.valorTotal)}
                             </p>
                             <p className="text-xs text-gray-500">
-                              {venda.quantidade} unidades • R$ {venda.precoUnitario.toFixed(2)} cada
+                              {venda.quantidade} unidades • {formatarMoeda(venda.precoUnitario)} cada
                               • {formatarDataHora(venda.dataHora)}
                             </p>
                             {venda.observacaoEspetinho && (

--- a/src/components/PainelPrincipal.tsx
+++ b/src/components/PainelPrincipal.tsx
@@ -19,6 +19,7 @@ import { Pedido } from '../types/Pedido';
 import { formatarDataHora } from '../functions/formatar-data-hora';
 import { useNavigation } from '../hooks/useNavigation';
 import _ from 'lodash';
+import { formatarMoeda } from '../functions/formatar-moeda';
 
 interface PainelPrincipalProps {
   saldoAtual: number;
@@ -232,7 +233,7 @@ export function PainelPrincipal({
               <DollarSign size={24} />
               <div>
                 <p className="text-orange-100 text-sm font-medium">Saldo em Caixa</p>
-                <p className="text-2xl font-bold">R$ {saldoAtual.toFixed(2)}</p>
+                <p className="text-2xl font-bold">{formatarMoeda(saldoAtual)}</p>
               </div>
             </div>
           </div>
@@ -402,7 +403,7 @@ export function PainelPrincipal({
                                         {item.quantidade}x {item.nomeEspetinho}
                                       </span>
                                       <span className="font-medium text-gray-900">
-                                        R$ {item.valorTotal.toFixed(2)}
+                                        {formatarMoeda(item.valorTotal)}
                                       </span>
                                     </div>
                                   ))}
@@ -415,7 +416,7 @@ export function PainelPrincipal({
                                   itens
                                 </span>
                                 <span className="font-bold text-gray-900">
-                                  Total: R$ {pedido.valorTotal.toFixed(2)}
+                                  Total: {formatarMoeda(pedido.valorTotal)}
                                 </span>
                               </div>
                             </div>
@@ -493,7 +494,7 @@ export function PainelPrincipal({
                                         {item.quantidade}x {item.nomeEspetinho}
                                       </span>
                                       <span className="font-medium text-gray-900">
-                                        R$ {item.valorTotal.toFixed(2)}
+                                        {formatarMoeda(item.valorTotal)}
                                       </span>
                                     </div>
                                   ))}
@@ -506,7 +507,7 @@ export function PainelPrincipal({
                                   itens
                                 </span>
                                 <span className="font-bold text-gray-900">
-                                  Total: R$ {pedido.valorTotal.toFixed(2)}
+                                  Total: {formatarMoeda(pedido.valorTotal)}
                                 </span>
                               </div>
                             </div>
@@ -560,7 +561,7 @@ export function PainelPrincipal({
                       </p>
                     </div>
                     <div className="text-right">
-                      <p className="font-bold text-red-600">R$ {pedido.valorTotal.toFixed(2)}</p>
+                      <p className="font-bold text-red-600">{formatarMoeda(pedido.valorTotal)}</p>
                       <p className="text-xs text-red-500">Pendente</p>
                     </div>
                   </div>
@@ -633,7 +634,7 @@ export function PainelPrincipal({
                         <div className="flex-1">
                           <h4 className="font-medium text-gray-900">{espetinho.nome}</h4>
                           <p className="text-sm text-gray-600">
-                            R$ {espetinho.preco.toFixed(2)} cada
+                            {formatarMoeda(espetinho.preco)} cada
                           </p>
                           {espetinho.observacao && (
                             <p className="text-xs text-gray-500 mt-1">{espetinho.observacao}</p>
@@ -673,7 +674,7 @@ export function PainelPrincipal({
                       {quantidade > 0 && (
                         <div className="text-right">
                           <p className="text-sm font-semibold text-orange-600">
-                            Subtotal: R$ {subtotal.toFixed(2)}
+                            Subtotal: {formatarMoeda(subtotal)}
                           </p>
                         </div>
                       )}
@@ -703,7 +704,7 @@ export function PainelPrincipal({
               <div className="flex justify-between items-center">
                 <span className="font-semibold text-gray-900">Total do Pedido:</span>
                 <span className="text-xl font-bold text-orange-600">
-                  R$ {calcularTotalPedido().toFixed(2)}
+                  {formatarMoeda(calcularTotalPedido())}
                 </span>
               </div>
               {clienteSelecionado && (
@@ -902,7 +903,7 @@ export function PainelPrincipal({
                   <div className="flex items-center justify-between mb-3">
                     <div className="flex-1">
                       <h4 className="font-medium text-gray-900">{espetinho.nome}</h4>
-                      <p className="text-sm text-gray-600">R$ {espetinho.preco.toFixed(2)} cada</p>
+                      <p className="text-sm text-gray-600">{formatarMoeda(espetinho.preco)} cada</p>
                       {espetinho.observacao && (
                         <p className="text-xs text-gray-500 mt-1">{espetinho.observacao}</p>
                       )}

--- a/src/components/TelaCadastros.tsx
+++ b/src/components/TelaCadastros.tsx
@@ -19,6 +19,7 @@ import { Espetinho } from '../types/Espetinho';
 import { Venda } from '../types/Venda';
 import { formatarDataHora } from '../functions/formatar-data-hora';
 import { useNavigation } from '../hooks/useNavigation';
+import { formatarMoeda } from '../functions/formatar-moeda';
 
 interface TelaCadastrosProps {
   clientes: Cliente[];
@@ -325,7 +326,7 @@ export function TelaCadastros({
                           </div>
                           <div className="text-right">
                             <p className="text-lg font-bold text-blue-600">
-                              R$ {totalGasto.toFixed(2)}
+                              {formatarMoeda(totalGasto)}
                             </p>
                             <p className="text-xs text-gray-500">total gasto</p>
                           </div>
@@ -382,7 +383,7 @@ export function TelaCadastros({
                           <h3 className="font-semibold text-gray-900 mb-2">{produto.nome}</h3>
                           <div className="flex items-center gap-4 text-sm text-gray-600 mb-2">
                             <span className="font-medium text-green-600">
-                              R$ {produto.preco.toFixed(2)}
+                              {formatarMoeda(produto.preco)}
                             </span>
                             <span>Padrão: {produto.quantidadeInicial || 0} unidades</span>
                           </div>
@@ -392,7 +393,7 @@ export function TelaCadastros({
                         </div>
                         <div className="text-right">
                           <p className="text-lg font-bold text-green-600">
-                            R$ {produto.preco.toFixed(2)}
+                            {formatarMoeda(produto.preco)}
                           </p>
                           <p className="text-xs text-gray-500">preço unitário</p>
                         </div>
@@ -555,7 +556,7 @@ export function TelaCadastros({
                 <div className="flex items-center gap-2">
                   <DollarSign size={16} />
                   <span>
-                    Total gasto: R$ {modalDetalhesCliente.cliente.totalCompras.toFixed(2)}
+                    Total gasto: {formatarMoeda(modalDetalhesCliente.cliente.totalCompras)}
                   </span>
                 </div>
               </div>
@@ -585,7 +586,7 @@ export function TelaCadastros({
                             </p>
                           </div>
                           <p className="font-bold text-blue-600">
-                            R$ {venda.valorTotal.toFixed(2)}
+                            {formatarMoeda(venda.valorTotal)}
                           </p>
                         </div>
                       </div>

--- a/src/components/TelaInicial.tsx
+++ b/src/components/TelaInicial.tsx
@@ -5,6 +5,7 @@ import { formatarDiaSemana } from '../functions/formatar-dia-semana';
 import { useNavigation } from '../hooks/useNavigation';
 import { formatarData } from '../functions/formatar-data';
 import { BotaoInstalarPWA } from './InstallPwaButton';
+import { formatarMoeda } from '../functions/formatar-moeda';
 
 interface TelaInicialProps {
   operacoes: ResumoOperacao[];
@@ -142,7 +143,7 @@ export function TelaInicial({
                               </span>
                             </div>
                             <p className="text-lg font-bold text-green-900">
-                              R$ {operacao.saldoFinal.toFixed(2)}
+                              {formatarMoeda(operacao.saldoFinal)}
                             </p>
                           </div>
 

--- a/src/components/VisaoPedidos.tsx
+++ b/src/components/VisaoPedidos.tsx
@@ -5,6 +5,7 @@ import { formatarDataHora } from '../functions/formatar-data-hora';
 import _ from 'lodash';
 import { useNavigation } from '../hooks/useNavigation';
 import { formatarStatusPedido } from '../functions/formatar-status-pedido';
+import { formatarMoeda } from '../functions/formatar-moeda';
 
 interface VisaoPedidosProps {
   pedidos: Pedido[];
@@ -115,7 +116,7 @@ export function VisaoPedidos({ pedidos }: VisaoPedidosProps) {
                     </div>
                     <div className="text-right">
                       <p className="text-lg font-bold text-orange-600">
-                        R$ {pedido.valorTotal.toFixed(2)}
+                        {formatarMoeda(pedido.valorTotal)}
                       </p>
                       <p className="text-xs text-gray-500">total</p>
                     </div>
@@ -137,7 +138,7 @@ export function VisaoPedidos({ pedidos }: VisaoPedidosProps) {
                             <h4 className="font-medium text-gray-900">{item.nomeEspetinho}</h4>
                             <div className="text-sm text-gray-600 mt-1">
                               <span>
-                                {item.quantidade}x unidades • R$ {item.precoUnitario.toFixed(2)}{' '}
+                                {item.quantidade}x unidades • {formatarMoeda(item.precoUnitario)}{' '}
                                 cada
                               </span>
                             </div>
@@ -149,7 +150,7 @@ export function VisaoPedidos({ pedidos }: VisaoPedidosProps) {
                           </div>
                           <div className="text-right">
                             <p className="font-semibold text-gray-900">
-                              R$ {item.valorTotal.toFixed(2)}
+                              {formatarMoeda(item.valorTotal)}
                             </p>
                           </div>
                         </div>

--- a/src/components/VisualizarOperacao.tsx
+++ b/src/components/VisualizarOperacao.tsx
@@ -14,6 +14,7 @@ import { copiarParaAreaDeTransferencia } from '../functions/copiar-area-transfer
 import { formataMetodoPagamento } from '../functions/formatar-metodo-pagamento';
 import { gerarTextoRelatorio } from '../functions/gerar-texto-relatorio';
 import { formatarData } from '../functions/formatar-data';
+import { formatarMoeda } from '../functions/formatar-moeda';
 
 interface VisualizarOperacaoProps {
   operacao: ResumoOperacao;
@@ -112,14 +113,14 @@ export function VisualizarOperacao({ operacao, onVoltar }: VisualizarOperacaoPro
               <div className="flex justify-between items-center">
                 <span className="text-gray-600">Saldo Inicial:</span>
                 <span className="font-semibold text-gray-900">
-                  R$ {operacao.saldoInicial?.toFixed(2) || '0,00'}
+                  {formatarMoeda(operacao.saldoInicial || 0)}
                 </span>
               </div>
 
               <div className="flex justify-between items-center">
                 <span className="text-gray-600">Total de Receita:</span>
                 <span className="font-semibold text-green-600">
-                  R$ {operacao.totalReceita?.toFixed(2) || '0,00'}
+                  {formatarMoeda(operacao.totalReceita || 0)}
                 </span>
               </div>
 
@@ -127,7 +128,7 @@ export function VisualizarOperacao({ operacao, onVoltar }: VisualizarOperacaoPro
                 <div className="flex justify-between items-center">
                   <span className="text-lg font-medium text-gray-900">Saldo Final:</span>
                   <span className="text-xl font-bold text-green-600">
-                    R$ {operacao.saldoFinal.toFixed(2)}
+                    {formatarMoeda(operacao.saldoFinal)}
                   </span>
                 </div>
               </div>
@@ -199,10 +200,11 @@ export function VisualizarOperacao({ operacao, onVoltar }: VisualizarOperacaoPro
               <div className="text-center">
                 <p className="text-sm text-blue-600 font-medium mb-1">Ticket Médio por Venda</p>
                 <p className="text-2xl font-bold text-blue-800">
-                  R${' '}
-                  {operacao.totalVendas > 0
-                    ? ((operacao.totalReceita || 0) / operacao.totalVendas).toFixed(2)
-                    : '0,00'}
+                  {formatarMoeda(
+                    operacao.totalVendas > 0
+                      ? (operacao.totalReceita || 0) / operacao.totalVendas
+                      : 0,
+                  )}
                 </p>
                 <p className="text-xs text-blue-600 mt-1">Valor médio por transação realizada</p>
               </div>
@@ -220,12 +222,12 @@ export function VisualizarOperacao({ operacao, onVoltar }: VisualizarOperacaoPro
                     <div className="flex justify-between items-start mb-2">
                       <h3 className="font-medium text-gray-900">{esp.nome}</h3>
                       <span className="font-bold text-orange-600">
-                        R$ {esp.receitaGerada.toFixed(2)}
+                        {formatarMoeda(esp.receitaGerada)}
                       </span>
                     </div>
                     <div className="text-sm text-gray-600 space-y-1">
                       <p>Vendidas: {esp.quantidadeVendida} unidades</p>
-                      <p>Preço unitário: R$ {esp.precoVenda.toFixed(2)}</p>
+                      <p>Preço unitário: {formatarMoeda(esp.precoVenda)}</p>
                       {esp.observacao && <p className="italic">"{esp.observacao}"</p>}
                     </div>
                   </div>
@@ -250,7 +252,7 @@ export function VisualizarOperacao({ operacao, onVoltar }: VisualizarOperacaoPro
                         )}
                       </div>
                       <span className="font-bold text-blue-600">
-                        R$ {cliente.totalGasto.toFixed(2)}
+                        {formatarMoeda(cliente.totalGasto)}
                       </span>
                     </div>
                     <div className="text-sm text-gray-600">
@@ -284,7 +286,7 @@ export function VisualizarOperacao({ operacao, onVoltar }: VisualizarOperacaoPro
                         </p>
                       </div>
                       <span className="font-bold text-purple-600">
-                        R$ {pagamento.valorTotal.toFixed(2)}
+                        {formatarMoeda(pagamento.valorTotal)}
                       </span>
                     </div>
                   </div>

--- a/src/functions/gerar-texto-relatorio.ts
+++ b/src/functions/gerar-texto-relatorio.ts
@@ -2,6 +2,7 @@ import { ResumoOperacao } from '../types/ResumoOperacao';
 import { formataMetodoPagamento } from './formatar-metodo-pagamento';
 import { formatarDataHora } from './formatar-data-hora';
 import { formatarDiaSemana } from './formatar-dia-semana';
+import { formatarMoeda } from './formatar-moeda';
 
 export function gerarTextoRelatorio(operacao: ResumoOperacao) {
   const data = formatarDataHora(operacao.dataOperacao);
@@ -11,19 +12,19 @@ export function gerarTextoRelatorio(operacao: ResumoOperacao) {
   texto += `📅 ${data} (${diaSemana})\n\n`;
 
   texto += `💰 RESUMO FINANCEIRO\n`;
-  texto += `• Saldo Inicial: R$ ${operacao.saldoInicial?.toFixed(2) || '0,00'}\n`;
-  texto += `• Total de Receita: R$ ${operacao.totalReceita?.toFixed(2) || '0,00'}\n`;
-  texto += `• Saldo Final: R$ ${operacao.saldoFinal.toFixed(2)}\n\n`;
+  texto += `• Saldo Inicial: ${formatarMoeda(operacao.saldoInicial || 0)}\n`;
+  texto += `• Total de Receita: ${formatarMoeda(operacao.totalReceita || 0)}\n`;
+  texto += `• Saldo Final: ${formatarMoeda(operacao.saldoFinal)}\n\n`;
 
   texto += `📈 RESUMO DE VENDAS\n`;
   texto += `• Total de Vendas: ${operacao.totalVendas}\n`;
   texto += `• Unidades Vendidas: ${operacao.totalUnidadesVendidas}\n`;
-  texto += `• Ticket Médio: R$ ${operacao.totalVendas > 0 ? ((operacao.totalReceita || 0) / operacao.totalVendas).toFixed(2) : '0,00'}\n\n`;
+  texto += `• Ticket Médio: ${formatarMoeda(operacao.totalVendas > 0 ? (operacao.totalReceita || 0) / operacao.totalVendas : 0)}\n\n`;
 
   if (operacao.resumoEspetinhos && operacao.resumoEspetinhos.length > 0) {
     texto += `🍢 VENDAS POR PRODUTO\n`;
     operacao.resumoEspetinhos.forEach((esp) => {
-      texto += `• ${esp.nome}: ${esp.quantidadeVendida} unidades - R$ ${esp.receitaGerada.toFixed(2)}\n`;
+      texto += `• ${esp.nome}: ${esp.quantidadeVendida} unidades - ${formatarMoeda(esp.receitaGerada)}\n`;
     });
     texto += `\n`;
   }
@@ -31,7 +32,7 @@ export function gerarTextoRelatorio(operacao: ResumoOperacao) {
   if (operacao.resumoClientes && operacao.resumoClientes.length > 0) {
     texto += `👥 VENDAS POR CLIENTE\n`;
     operacao.resumoClientes.forEach((cliente) => {
-      texto += `• ${cliente.nome}: ${cliente.quantidadePedidos} pedidos - R$ ${cliente.totalGasto.toFixed(2)}\n`;
+      texto += `• ${cliente.nome}: ${cliente.quantidadePedidos} pedidos - ${formatarMoeda(cliente.totalGasto)}\n`;
     });
     texto += `\n`;
   }
@@ -39,7 +40,7 @@ export function gerarTextoRelatorio(operacao: ResumoOperacao) {
   if (operacao.resumoPagamentos && operacao.resumoPagamentos.length > 0) {
     texto += `💳 MÉTODOS DE PAGAMENTO\n`;
     operacao.resumoPagamentos.forEach((pagamento) => {
-      texto += `• ${formataMetodoPagamento(pagamento.metodoPagamento)}: ${pagamento.quantidade} transações - R$ ${pagamento.valorTotal.toFixed(2)}\n`;
+      texto += `• ${formataMetodoPagamento(pagamento.metodoPagamento)}: ${pagamento.quantidade} transações - ${formatarMoeda(pagamento.valorTotal)}\n`;
     });
     texto += `\n`;
   }


### PR DESCRIPTION
## Summary
- replace manual `R$` string and `toFixed` usage with centralized `formatarMoeda` helper across components and report text generation
- ensure consistent monetary display in financial summaries, product listings, and payment screens

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected token 'export')*

------
https://chatgpt.com/codex/tasks/task_e_688b948eae488325ba2918f869d2013b