### PR TITLE
fix: format currency with locale

### DIFF
--- a/src/functions/formatar-moeda.ts
+++ b/src/functions/formatar-moeda.ts
@@ -1,5 +1,5 @@
 export function formatarMoeda(valorMonetario: number) {
-  return new Intl.NumberFormat('pt-Br', {
+  return new Intl.NumberFormat('pt-BR', {
     style: 'currency',
     currency: 'BRL',
   }).format(valorMonetario);

--- a/src/functions/gerar-texto-relatorio.ts
+++ b/src/functions/gerar-texto-relatorio.ts
@@ -2,6 +2,7 @@ import { ResumoOperacao } from '../types/ResumoOperacao';
 import { formataMetodoPagamento } from './formatar-metodo-pagamento';
 import { formatarDataHora } from './formatar-data-hora';
 import { formatarDiaSemana } from './formatar-dia-semana';
+import { formatarMoeda } from './formatar-moeda';
 
 export function gerarTextoRelatorio(operacao: ResumoOperacao) {
   const data = formatarDataHora(operacao.dataOperacao);
@@ -11,19 +12,23 @@ export function gerarTextoRelatorio(operacao: ResumoOperacao) {
   texto += `📅 ${data} (${diaSemana})\n\n`;
 
   texto += `💰 RESUMO FINANCEIRO\n`;
-  texto += `• Saldo Inicial: R$ ${operacao.saldoInicial?.toFixed(2) || '0,00'}\n`;
-  texto += `• Total de Receita: R$ ${operacao.totalReceita?.toFixed(2) || '0,00'}\n`;
-  texto += `• Saldo Final: R$ ${operacao.saldoFinal.toFixed(2)}\n\n`;
+  texto += `• Saldo Inicial: ${formatarMoeda(operacao.saldoInicial ?? 0)}\n`;
+  texto += `• Total de Receita: ${formatarMoeda(operacao.totalReceita ?? 0)}\n`;
+  texto += `• Saldo Final: ${formatarMoeda(operacao.saldoFinal)}\n\n`;
 
   texto += `📈 RESUMO DE VENDAS\n`;
   texto += `• Total de Vendas: ${operacao.totalVendas}\n`;
   texto += `• Unidades Vendidas: ${operacao.totalUnidadesVendidas}\n`;
-  texto += `• Ticket Médio: R$ ${operacao.totalVendas > 0 ? ((operacao.totalReceita || 0) / operacao.totalVendas).toFixed(2) : '0,00'}\n\n`;
+  const ticketMedio =
+    operacao.totalVendas > 0
+      ? (operacao.totalReceita ?? 0) / operacao.totalVendas
+      : 0;
+  texto += `• Ticket Médio: ${formatarMoeda(ticketMedio)}\n\n`;
 
   if (operacao.resumoEspetinhos && operacao.resumoEspetinhos.length > 0) {
     texto += `🍢 VENDAS POR PRODUTO\n`;
     operacao.resumoEspetinhos.forEach((esp) => {
-      texto += `• ${esp.nome}: ${esp.quantidadeVendida} unidades - R$ ${esp.receitaGerada.toFixed(2)}\n`;
+      texto += `• ${esp.nome}: ${esp.quantidadeVendida} unidades - ${formatarMoeda(esp.receitaGerada)}\n`;
     });
     texto += `\n`;
   }
@@ -31,7 +36,7 @@ export function gerarTextoRelatorio(operacao: ResumoOperacao) {
   if (operacao.resumoClientes && operacao.resumoClientes.length > 0) {
     texto += `👥 VENDAS POR CLIENTE\n`;
     operacao.resumoClientes.forEach((cliente) => {
-      texto += `• ${cliente.nome}: ${cliente.quantidadePedidos} pedidos - R$ ${cliente.totalGasto.toFixed(2)}\n`;
+      texto += `• ${cliente.nome}: ${cliente.quantidadePedidos} pedidos - ${formatarMoeda(cliente.totalGasto)}\n`;
     });
     texto += `\n`;
   }
@@ -39,7 +44,7 @@ export function gerarTextoRelatorio(operacao: ResumoOperacao) {
   if (operacao.resumoPagamentos && operacao.resumoPagamentos.length > 0) {
     texto += `💳 MÉTODOS DE PAGAMENTO\n`;
     operacao.resumoPagamentos.forEach((pagamento) => {
-      texto += `• ${formataMetodoPagamento(pagamento.metodoPagamento)}: ${pagamento.quantidade} transações - R$ ${pagamento.valorTotal.toFixed(2)}\n`;
+      texto += `• ${formataMetodoPagamento(pagamento.metodoPagamento)}: ${pagamento.quantidade} transações - ${formatarMoeda(pagamento.valorTotal)}\n`;
     });
     texto += `\n`;
   }


### PR DESCRIPTION
## Summary
- fix Brazilian currency locale in formatter
- apply currency formatter throughout report generation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: SyntaxError: Unexpected token 'export')
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688b7f049f54832585fe5df4e01acd31