### PR TITLE
feat: add reusable button and input components

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,20 @@
+import { forwardRef, ComponentProps } from 'react';
+
+interface ButtonProps extends ComponentProps<'button'> {
+  variant?: 'primary' | 'secondary';
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ variant = 'primary', className = '', ...rest }, ref) => {
+    const base =
+      'px-4 py-2 rounded font-medium focus:outline-none focus:ring-2 focus:ring-offset-2';
+    const variants = {
+      primary: 'bg-orange-500 text-white hover:bg-orange-600 focus:ring-orange-500',
+      secondary: 'bg-gray-200 text-gray-700 hover:bg-gray-300 focus:ring-gray-300',
+    };
+
+    return <button ref={ref} className={`${base} ${variants[variant]} ${className}`} {...rest} />;
+  },
+);
+
+Button.displayName = 'Button';

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,0 +1,13 @@
+import { forwardRef, ComponentProps } from 'react';
+
+export const Input = forwardRef<HTMLInputElement, ComponentProps<'input'>>(
+  ({ className = '', ...rest }, ref) => (
+    <input
+      ref={ref}
+      className={`w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-orange-500 ${className}`}
+      {...rest}
+    />
+  ),
+);
+
+Input.displayName = 'Input';


### PR DESCRIPTION
## Summary
- add reusable Button component with primary and secondary variants
- add Input component for consistent form styling

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: SyntaxError: Unexpected token 'export')
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688b80bf2df8832591cd854339608ffb